### PR TITLE
Feature/resumen pedido

### DIFF
--- a/src/app/ver-pedidos/ver-pedidos.component.html
+++ b/src/app/ver-pedidos/ver-pedidos.component.html
@@ -1,6 +1,45 @@
 
-<div class="container-sm">
-  <app-direccion> </app-direccion>
+<div class="container-sm espacio">
+  <div class="modal-header ">
+    <div class="col-2">
+      <button (click)="regresar()" type="button" class="p-0 btn btn-outline-secondary"><i class="bi bi-chevron-left"></i></button>
+    </div>
+    <div class="col-8 text-center">
+      <p>Resumen del pedido</p>
+    </div>
+    <div class="col-2">
+    </div>
+  </div>
+  <!--Direccion de envio-->
+  <div class="text-center">
+    <app-direccion> </app-direccion>
+  </div>
+  <!--Metodo de pago-->
+  <div>
 
+  </div>
+  <!--Tu pedido y vaciar-->
+  <div class="row ep-2">
+    <div class="col-8 tupedido">
+      <p>Tu pedido</p>
+    </div>
+    <div class="col-4 p-0 m-0" >
+      <div class="vaciar" (click)="vaciar()">
+        <button>
+          <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M13 10V15M3 5H19L17.42 19.22C17.3658 19.7094 17.1331 20.1616 16.7663 20.49C16.3994 20.8184 15.9244 21 15.432 21H6.568C6.07564 21 5.60056 20.8184 5.23375 20.49C4.86693 20.1616 4.63416 19.7094 4.58 19.22L3 5ZM6.345 2.147C6.50675 1.80397 6.76271 1.514 7.083 1.31091C7.4033 1.10782 7.77474 0.999996 8.154 1H13.846C14.2254 0.999806 14.5971 1.10755 14.9176 1.31064C15.2381 1.51374 15.4942 1.80381 15.656 2.147L17 5H5L6.345 2.147V2.147ZM1 5H21H1ZM9 10V15V10Z" stroke="#EA1C1C" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </button>
+        <p>Vaciar</p>
+      </div>
+    </div>
+  </div>
+  <!--Lista de platillos-->
+  <div>
+    <app-lista-platillos [pedidoOrdenado]="pedidoAlmuerzo"></app-lista-platillos>
+  </div>
+  <!--Resumen Orden-->
+  <div>
+    <!--Aqui ira la etiqueta del componente resumen orden-->
+  </div>
 </div>
-

--- a/src/app/ver-pedidos/ver-pedidos.component.html
+++ b/src/app/ver-pedidos/ver-pedidos.component.html
@@ -2,7 +2,7 @@
 <div class="container-sm espacio">
   <div class="modal-header ">
     <div class="col-2">
-      <button (click)="regresar()" type="button" class="p-0 btn btn-outline-secondary"><i class="bi bi-chevron-left"></i></button>
+      <button routerLink="/menu" type="button" class="p-0 btn btn-outline-secondary"><i class="bi bi-chevron-left"></i></button>
     </div>
     <div class="col-8 text-center">
       <p>Resumen del pedido</p>
@@ -12,11 +12,11 @@
   </div>
   <!--Direccion de envio-->
   <div class="text-center">
-    <app-direccion  (valiDireccion)="validarBtnOrden($event)"> </app-direccion>
+    <app-direccion > </app-direccion>
   </div>
   <!--Metodo de pago-->
-  <div>
-
+  <div class="text-center">
+    <!--AQUI IRA LA ETIQUETA DE METODO DE PAGO-->
   </div>
   <!--Tu pedido y vaciar-->
   <div class="row ep-2">
@@ -36,8 +36,8 @@
   </div>
   <!--Lista de platillos-->
   <div class="posicion2">
-    <app-lista-platillos [pedidoOrdenado]="pedidoAlmuerzo" (enviarOrden)="detallesOrden($event)"></app-lista-platillos>
+    <app-lista-platillos [pedidoOrdenado]="pedidoAlmuerzo"></app-lista-platillos>
   </div>
 </div>
 <!--Resumen Orden-->
-<app-resumen-orden [sumaPedido]="sumPedido" [envio]="costoEnvio" [pedidoAlmuerzo]="descripcionOrden" [validacionPedido]="validacionP" (valiPlatillos)="validarListaP($event)"></app-resumen-orden>
+<!--AQUI IRA LA ETIQUETA DE RESUMEN ORDEN-->

--- a/src/app/ver-pedidos/ver-pedidos.component.html
+++ b/src/app/ver-pedidos/ver-pedidos.component.html
@@ -12,7 +12,7 @@
   </div>
   <!--Direccion de envio-->
   <div class="text-center">
-    <app-direccion> </app-direccion>
+    <app-direccion  (valiDireccion)="validarBtnOrden($event)"> </app-direccion>
   </div>
   <!--Metodo de pago-->
   <div>
@@ -35,11 +35,9 @@
     </div>
   </div>
   <!--Lista de platillos-->
-  <div>
-    <app-lista-platillos [pedidoOrdenado]="pedidoAlmuerzo"></app-lista-platillos>
-  </div>
-  <!--Resumen Orden-->
-  <div>
-    <!--Aqui ira la etiqueta del componente resumen orden-->
+  <div class="posicion2">
+    <app-lista-platillos [pedidoOrdenado]="pedidoAlmuerzo" (enviarOrden)="detallesOrden($event)"></app-lista-platillos>
   </div>
 </div>
+<!--Resumen Orden-->
+<app-resumen-orden [sumaPedido]="sumPedido" [envio]="costoEnvio" [pedidoAlmuerzo]="descripcionOrden" [validacionPedido]="validacionP" (valiPlatillos)="validarListaP($event)"></app-resumen-orden>

--- a/src/app/ver-pedidos/ver-pedidos.component.scss
+++ b/src/app/ver-pedidos/ver-pedidos.component.scss
@@ -81,6 +81,12 @@ svg{
   height: 20px;
 }
 
+.posicion2{
+  width: 100%;
+  height: 50vh;
+  overflow: auto;
+}
+
 @media screen and (max-width:350px){
   .btn{
     width: 35px;

--- a/src/app/ver-pedidos/ver-pedidos.component.scss
+++ b/src/app/ver-pedidos/ver-pedidos.component.scss
@@ -1,0 +1,107 @@
+.modal-header{
+  border: 0;
+  margin: 0;
+  padding: 0;
+  padding-bottom: 0;
+}
+
+p{
+  font-family: "Poppins";
+  margin: 0;
+}
+
+.btn{
+  width: 45px;
+  height: 45px;
+  border: 0;
+  background-color: #FFFFFF;
+  border-radius: 10px;
+  color: black;
+  text-align:left;
+  text-align: center;
+}
+
+.bi{
+  font-size: large;
+}
+
+.ep-2{
+  margin: 20px 10px;
+}
+
+.col-8 p{
+  margin: auto;
+  font-size: 18px;
+  line-height: 30px;
+  font-weight: 600;
+}
+
+.modal-header h4{
+  margin: 0 auto;
+}
+
+.espacio{
+  padding-top: 80px;
+}
+
+.tupedido{
+  margin: 0;
+  padding: 0;
+}
+
+.tupedido p{
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.vaciar{
+  font-weight: 700;
+  float:right;
+  justify-content: center;
+  color: #EA1C1C;
+  margin: auto;
+}
+
+.vaciar button{
+  margin: 0;
+  padding: 0;
+  top: 0;
+  border: none;
+  background: #f6f6f6;
+}
+
+.vaciar p{
+  margin-left: 2px;
+  font-size: 16px;
+  display: inline-block;
+}
+
+svg{
+  width: 20px;
+  height: 20px;
+}
+
+@media screen and (max-width:350px){
+  .btn{
+    width: 35px;
+    height: 35px;
+  }
+
+  .col-8 p{
+    font-size: 16px;
+  }
+
+  .tupedido p{
+    font-size: 14px;
+  }
+
+  .vaciar p{
+    font-size: 14px;
+  }
+
+  .vaciar button svg{
+    width: 15px;
+    height: 15px;
+  }
+}
+

--- a/src/app/ver-pedidos/ver-pedidos.component.ts
+++ b/src/app/ver-pedidos/ver-pedidos.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
 import { Pedido } from '../menu/interfaces/platillos';
 
 @Component({
@@ -7,18 +6,11 @@ import { Pedido } from '../menu/interfaces/platillos';
   templateUrl: './ver-pedidos.component.html',
   styleUrls: ['./ver-pedidos.component.scss']
 })
-export class VerPedidosComponent implements OnInit {
+export class VerPedidosComponent {
   pedidoAlmuerzo:Pedido[] = [];
   validacionP!:boolean;
 
-  constructor(private router: Router) { }
-
-  ngOnInit(): void {
-  }
-
-  regresar(){
-    this.router.navigateByUrl('menu');
-  }
+  constructor() { }
 
   vaciar(){
     localStorage.removeItem('pedido');

--- a/src/app/ver-pedidos/ver-pedidos.component.ts
+++ b/src/app/ver-pedidos/ver-pedidos.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { Pedido } from '../menu/interfaces/platillos';
 
 @Component({
   selector: 'app-ver-pedidos',
@@ -6,10 +8,22 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./ver-pedidos.component.scss']
 })
 export class VerPedidosComponent implements OnInit {
+  pedidoAlmuerzo:Pedido[] = [];
+  validacionP!:boolean;
 
-  constructor() { }
+  constructor(private router: Router) { }
 
   ngOnInit(): void {
   }
 
+  regresar(){
+    this.router.navigateByUrl('menu');
+  }
+
+  vaciar(){
+    localStorage.removeItem('pedido');
+    localStorage.removeItem('platoNum');
+    this.pedidoAlmuerzo =[];
+    this.validacionP=false;
+  }
 }

--- a/src/app/ver-pedidos/ver-pedidos.component.ts
+++ b/src/app/ver-pedidos/ver-pedidos.component.ts
@@ -8,7 +8,6 @@ import { Pedido } from '../menu/interfaces/platillos';
 })
 export class VerPedidosComponent {
   pedidoAlmuerzo:Pedido[] = [];
-  validacionP!:boolean;
 
   constructor() { }
 
@@ -16,6 +15,5 @@ export class VerPedidosComponent {
     localStorage.removeItem('pedido');
     localStorage.removeItem('platoNum');
     this.pedidoAlmuerzo =[];
-    this.validacionP=false;
   }
 }


### PR DESCRIPTION

-Al hacer clic en botón de Regresar podré acceder al menú anterior.
![image](https://user-images.githubusercontent.com/104949710/171903141-1c30fb2b-a797-435e-b834-63506f1241c1.png)

-Al regresar a la pantalla anterior deberá enviar la configuración del pedido actual.
+ debido a que en la historia de usuario "lista platillos ordenados" van guardando los cambios hechos en los pedidos en la localstorage, hacerlo aquí sería redundante, por tal motivo se decidió omitirlo y solo hacer que te redirija a la pantalla menú.

-Al regresar a la pantalla anterior deberá guardar las configuraciones actuales (dirección de envío y tipo de pago si se confirmaron).
+ Esta parte del guardado de la dirección de envió se realiza en el modulo de dirección y el tipo de pago aun no ha sido implementado por lo que también se decidió omitirlo, para reducir las líneas de código.

-Al hacer clic en el icono de Vaciar me borrará los platos de mi pedido actual.
![image](https://user-images.githubusercontent.com/104949710/171904492-3f39b507-1277-4293-8514-072a57ca7fe8.png)
+ Se remueve el pedido y platonum del localstorage los cuales tienen información de los pedidos y se coloca la variable pedidoAlmuerzo como vacío.

se agregaron las etiquetas de los componentes de lista-platillo y resumen-orden.
![image](https://user-images.githubusercontent.com/104949710/171985552-edd600ca-3759-4cb5-accc-3a023c0ab2c1.png)

